### PR TITLE
Added port 7785 from on-prem.

### DIFF
--- a/rubrik_cloudon.template
+++ b/rubrik_cloudon.template
@@ -142,6 +142,13 @@
                 },
                 {
                   "IpProtocol" : "tcp",
+                  "FromPort" : "7785",
+                  "ToPort" : "7785",
+                  "CidrIp" : { "Ref" : "OnPremRubrikCIDR" },
+                  "Description" : { "Ref" : "SecurityGroupRoleDescription" }
+                },
+                {
+                  "IpProtocol" : "tcp",
                   "FromPort" : "8077",
                   "ToPort" : "8077",
                   "CidrIp" : { "Ref" : "OnPremRubrikCIDR" },


### PR DESCRIPTION
# Description

Added port 7785 from the on-prem Rubrik appliance to the rubrik-cloudon security group. Required by CDM 5.0.1.

## Related Issue

Fixes #14 & #18 

## Motivation and Context

Fixes access issues to Bolt and Converter from CDM 5.0.1.

## How Has This Been Tested?

Deployed the CFT and verified that the security group includes port 7785 from the on-prem appliance. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
