### PR TITLE
CloudOn template update - added outputs, GetBucketAcl, and KMS key support

### DIFF
--- a/rubrik_cloudon.template
+++ b/rubrik_cloudon.template
@@ -117,7 +117,8 @@
         "CreateVMImport" : { "Fn::Equals" : [ {"Ref" : "CreateVMImportRole"}, "yes" ] },
         "DontCreateVMImport" : { "Fn::Equals" : [ {"Ref" : "CreateVMImportRole"}, "no" ] },
         "CreateIAMuser" : { "Fn::Equals" : [ {"Ref" : "CreateNewUser"}, "yes" ] },
-        "DontCreateIAMuser" : { "Fn::Equals" : [ {"Ref" : "CreateNewUser"}, "no" ] }
+        "DontCreateIAMuser" : { "Fn::Equals" : [ {"Ref" : "CreateNewUser"}, "no" ] },
+        "CreateKMS" : { "Fn::Equals" : [ {"Ref" : "UseKMS"}, "yes" ] }
 
     },
 

--- a/rubrik_cloudon.template
+++ b/rubrik_cloudon.template
@@ -1,6 +1,6 @@
 {
 "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "Complete the AWS configuration process required for the Rubrik CloudOn feature which provides the ability to convert a snapshot, an archived snapshot, or a replica into an Amazon Machine Image (AMI) and then run that AMI on an Amazon virtual private cloud.",
+    "Description": "Complete the AWS configuration process required for the Rubrik CloudOn feature. CloudOn provides the ability to convert a local snapshot, an archived snapshot, or a replica into an Amazon Machine Image (AMI), and then run that AMI on an Amazon virtual private cloud.",
     "Metadata": {
         "AWS::CloudFormation::Interface" : {
             "ParameterGroups" : [
@@ -36,7 +36,7 @@
         },
 
         "S3BucketName": {
-            "Description": "The name of the S3 Bucket used as a Rubrik archival location.",
+            "Description": "The name of the S3 Bucket to be used as a Rubrik archival location.",
             "Type": "String"
         },
 
@@ -48,9 +48,9 @@
         "OnPremRubrikCIDR" : {
             "Type"				: "String",
             "Default"			: "10.79.0.0/24",
-            "Description"			: "The CIDR block for your on-prem Rubrik Cluster.",
+            "Description"			: "The CIDR block for your on-premise Rubrik Cluster.",
             "AllowedPattern"		: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-            "ConstraintDescription"		: "Please enter a valid IP CIDR range in the form x.x.x.x/x."
+            "ConstraintDescription"		: "Enter a valid IP CIDR range in the form x.x.x.x/x."
           },
         
         "CreateVMImportRole": {
@@ -70,11 +70,19 @@
           },
 
         "IAMUserName" : {
-            "Description": "The name of the IAM User to assign the new CloudOn specific policies to.",
+            "Description": "The name of the IAM User to assign the new CloudOn-specific policies to.",
             "Type": "String",
             "Default": "rubrik"
         },
 
+        "UseKMS": {
+            "Description": "Create a new KMS key for encryption.",
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [ "yes", "no" ],
+            "ConstraintDescription": "Choose 'yes' to create a new KMS Key for encryption"
+        },
+      
         "SecurityGroupName": {
             "Description": "The name of the Security Group specific to Rubrik CloudOn.",
             "Type": "String",
@@ -93,7 +101,7 @@
             "Default": "Ports required for Rubrik CloudOn."
         },
         "VMImportPolicyName": {
-            "Description": "Name of Rubrik CloudOn specific policy for the VM Import Role.",
+            "Description": "Name of Rubrik CloudOn-specific policy for the VM Import Role.",
             "Type": "String",
             "Default": "rubrik-vmimport-role"
         }
@@ -519,6 +527,60 @@
                 "Users": [ { "Ref" : "IAMUserName" } ]
             }
         }
+         "CreateKMSKey" : {
+            "Type" : "AWS::KMS::Key",
+            "Condition" : "CreateKMS",
+            "Properties" : {
+                "Description" : "Rubrik archive location encryption",
+                "KeyPolicy" : {
+                    "Version": "2012-10-17",
+                    "Id": { "Fn::Join" : [ "", [ "rubrik-encryption-", { "Ref": "S3BucketName" } ] ] },
+                    "Statement": [
+                         {
+                            "Sid": "Enable IAM User Permissions",
+                            "Effect": "Allow",
+                            "Principal": {
+                                
+                                "AWS": { "Fn::Join" : [ "", [ "arn:aws:iam::", { "Ref": "AWS::AccountId" }, ":root" ] ] }
+                            },
+                            "Action": "kms:*",
+                            "Resource": "*"
+                        },
+                        {
+                            "Sid": "Allow use of the key",
+                            "Effect": "Allow",
+                            "Principal": { "AWS": { 
+                                "Fn::If": ["CreateIAMuser", { 
+                                        "Fn::GetAtt" : [ "CreateNewIAMUser", "Arn" ] 
+                                    }, { 
+                                        "Fn::Join" : [ "", [ "arn:aws:iam::", { "Ref": "AWS::AccountId" }, ":user/", {"Ref" : "IAMUserName"} ] ] 
+                                    } ]
+                                } 
+                            },
+                            "Action": [
+                                "kms:Encrypt",
+                                "kms:Decrypt",
+                                "kms:ReEncrypt*",
+                                "kms:GenerateDataKey*",
+                                "kms:DescribeKey"
+                            ], 
+                            "Resource": "*"
+                        }    
+                    ]
+                }
+            }
+        },
+
+        "KMSKeyAlias" : {
+            "Type" : "AWS::KMS::Alias",
+            "DependsOn" : "CreateKMSKey",
+            "Condition" : "CreateKMS",
+            "Properties" : {
+                "AliasName" : { "Fn::Join" : [ "", [ "alias/rubrik-encryption-", { "Ref": "S3BucketName" } ] ] },
+                "TargetKeyId" : {"Ref":"CreateKMSKey"}
+            }
+    }
+
         
     },
     
@@ -532,6 +594,14 @@
           "Condition": "CreateIAMuser",
           "Description": "Secret Key for the new IAM user.",
           "Value" : { "Fn::GetAtt" : [ "IAMUserAccessKeys", "SecretAccessKey" ] }
+        },
+        "AWSBucketName" : {
+          "Description": "The S3 Bucket name.",
+          "Value" : { "Ref" : "S3BucketName" }
+        },
+        "Region": {
+          "Description": "The AWS Region where the configuration took place.",
+          "Value" : { "Ref" : "AWS::Region" } 
         },
         "SecurityGroupId" : {
           "Description": "ID for the newly created Security Group",

--- a/rubrik_cloudon.template
+++ b/rubrik_cloudon.template
@@ -324,6 +324,7 @@
                                 "s3:DeleteObject",
                                 "s3:DeleteBucket",
                                 "s3:GetBucketLocation",
+                                "s3:GetBucketAcl",
                                 "s3:ListBucket",
                                 "s3:ListMultipartUploadParts",
                                 "s3:PutObject",
@@ -439,6 +440,7 @@
                                 "s3:DeleteObject",
                                 "s3:DeleteBucket",
                                 "s3:GetBucketLocation",
+                                "s3:GetBucketAcl",
                                 "s3:ListBucket",
                                 "s3:ListMultipartUploadParts",
                                 "s3:PutObject",
@@ -598,6 +600,11 @@
         "AWSBucketName" : {
           "Description": "The S3 Bucket name.",
           "Value" : { "Ref" : "S3BucketName" }
+        },
+        "KMSKeyId" : {
+          "Condition" : "CreateKMS",
+          "Description": "The KMS Key ID used for encryption.",
+          "Value" : { "Ref" : "CreateKMSKey" }
         },
         "Region": {
           "Description": "The AWS Region where the configuration took place.",

--- a/rubrik_cloudon.template
+++ b/rubrik_cloudon.template
@@ -528,7 +528,7 @@
                 },
                 "Users": [ { "Ref" : "IAMUserName" } ]
             }
-        }
+        },
          "CreateKMSKey" : {
             "Type" : "AWS::KMS::Key",
             "Condition" : "CreateKMS",

--- a/rubrik_cloudon.template
+++ b/rubrik_cloudon.template
@@ -18,7 +18,7 @@
               },
               {
                 "Label": { "default" : "Optional" },
-                "Parameters": [ "SecurityGroupName", "SecurityGroupDescription", "SecurityGroupRoleDescription", "UserPolicyName", "VMImportPolicyName" ]
+                "Parameters": [ "SecurityGroupName", "SecurityGroupDescription", "SecurityGroupRoleDescription", "UserPolicyName", "UseKMS", "VMImportPolicyName" ]
               }
             ]
           }


### PR DESCRIPTION
Added AWSBucketName, KMSKeyId, and Region to Outputs (copied from CloudOut template).
Added CreateKMSKey and KMSKeyAlias to Resources (copied from CloudOut template).
Added GetBucketAcl permission to two CloudOut policy sections (to match permission in CloudOut template).

# Description

Updating CloudOn template to provide same information as CloudOut template.

## Related Issue

Added code to the CloudOn template to address these three issues:
fixes #25
fixes #23 
fixes #22

# Motivation and Context

This pull request addresses issues #22 and #23 by adding information to the Outputs tab in the AWS console, which can then be copied and pasted into the Rubrik CDM web UI. This simplifies the process for the user.
This pull request also addresses issue #25 by adding the GetBucketAcl permission for "CreateCloudOutPolicyForNewUser" and "CreateCloudOutPolicyForExistingUser". Adding the GetBucketAcl permission also satisfies CDM-199193.

## How Has This Been Tested?

Changes were tested in AWS. Account has admin privileges, to allow a KMS key to be created. Checked that all new outputs appeared in the Outputs tab in AWS.   
                                                                   
## Screenshots (if appropriate):

<img width="808" alt="Screen_Shot_2020-10-02_at_5_18_22_PM" src="https://user-images.githubusercontent.com/41892325/94980191-35fcac80-04dc-11eb-8196-25a27dd2b36c.png">

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

